### PR TITLE
Switch to Browser.element with SPA navigation

### DIFF
--- a/ext.browser.js
+++ b/ext.browser.js
@@ -21,7 +21,7 @@ function extBrowserSetup(app, spaFlags, document, ele) {
     ele.addEventListener("click", function(event) {
         if (event.metaKey || event.ctrlKey) return;
         if (! (event.target && event.target.href)) return;
-        if (! isChild(event.target)) return;
+        if (event.target.target || !isChild(event.target)) return;
         event.preventDefault();
         app.ports.onLocationRequest.send([locationObject(window.location), locationObject(event.target)]);
     }, false);

--- a/ext.browser.js
+++ b/ext.browser.js
@@ -18,12 +18,18 @@ function extBrowserSetup(app, spaFlags, document, ele) {
         if (node === ele) return true;
         return (node && isChild(node.parentNode));
     }
+    // elm only handles http https links. e.g. leave mailto: alone
+    function httpxNode(node) {
+        if (!node || (node.href && node.href.startsWith('http'))) return node;
+        return httpxNode(node.parentNode);
+    }
     ele.addEventListener("click", function(event) {
         if (event.metaKey || event.ctrlKey) return;
-        if (! (event.target && event.target.href)) return;
-        if (event.target.target || !isChild(event.target)) return;
+        const anchorTag = httpxNode(event.target);
+        if (!anchorTag) return;
+        if (anchorTag.target || !isChild(anchorTag)) return;
         event.preventDefault();
-        app.ports.onLocationRequest.send([locationObject(window.location), locationObject(event.target)]);
+        app.ports.onLocationRequest.send([locationObject(window.location), locationObject(anchorTag)]);
     }, false);
     window.addEventListener("popstate", function(event) {
         app.ports.onLocationChange.send(locationObject(window.location));

--- a/ext.browser.js
+++ b/ext.browser.js
@@ -1,0 +1,55 @@
+function locationObject(loc) {
+    return { protocol : loc.protocol
+           , host : loc.hostname
+           , port_ : loc.port
+           , pathname : loc.pathname
+           , search : loc.search
+           , hash : loc.hash
+           }
+}
+function generateSpaFlags() {
+  return {
+      location: locationObject(window.location),
+      navKey: Math.random()
+  }
+}
+function extBrowserSetup(app, spaFlags, document, ele) {
+    function isChild(node) {
+        if (node === ele) return true;
+        return (node && isChild(node.parentNode));
+    }
+    ele.addEventListener("click", function(event) {
+        if (! isChild(event.target)) return;
+        if (! (event.target && event.target.href)) return;
+        event.preventDefault();
+        app.ports.onLocationRequest.send([locationObject(window.location), locationObject(event.target)]);
+    }, false);
+    window.addEventListener("popstate", function(event) {
+        app.ports.onLocationChange.send(locationObject(window.location));
+    }, false);
+    if (app.ports.pushUrl) app.ports.pushUrl.subscribe(function(args) {
+        if (args[0] !== spaFlags.navKey) return;
+        history.pushState({}, '', args[1]);
+        app.ports.onLocationChange.send(locationObject(window.location));
+    });
+    if (app.ports.replaceUrl) app.ports.replaceUrl.subscribe(function(args) {
+        if (args[0] !== spaFlags.navKey) return;
+        history.replaceState({}, '', args[1]);
+        app.ports.onLocationChange.send(locationObject(window.location));
+    });
+    if (app.ports.back) app.ports.back.subscribe(function(args) {
+        if (args[0] !== spaFlags.navKey) return;
+        history.go(-args[1]);
+        app.ports.onLocationChange.send(locationObject(window.location));
+    });
+    if (app.ports.forward) app.ports.forward.subscribe(function(args) {
+        if (args[0] !== spaFlags.navKey) return;
+        history.go(args[1]);
+        app.ports.onLocationChange.send(locationObject(window.location));
+    });
+
+    var cachedPageTitle = document.title;
+    if (app.ports.setPageTitle) app.ports.setPageTitle.subscribe(function(pageTitle) {
+        if (cachedPageTitle !== pageTitle) document.title = cachedPageTitle = pageTitle;
+    });
+}

--- a/ext.browser.js
+++ b/ext.browser.js
@@ -18,12 +18,24 @@ function extBrowserSetup(app, spaFlags, document, ele) {
         if (node === ele) return true;
         return (node && isChild(node.parentNode));
     }
+    function isContentEditable(node) {
+        if (!node) return false;
+        return (
+          node.contentEditable === 'true' ||
+          node.contentEditable === true   ||
+          isContentEditable(node.parentNode)
+        );
+    }
     // elm only handles http https links. e.g. leave mailto: alone
     function httpxNode(node) {
-        if (!node || (node.href && node.href.startsWith('http'))) return node;
+        if (!node || (node.href && typeof node.href.startsWith == 'function' && node.href.startsWith('http'))) return node;
         return httpxNode(node.parentNode);
     }
     ele.addEventListener("click", function(event) {
+        if (isContentEditable(event.target)) {
+            event.preventDefault();
+            return false;
+        }
         if (event.metaKey || event.ctrlKey) return;
         const anchorTag = httpxNode(event.target);
         if (!anchorTag) return;

--- a/ext.browser.js
+++ b/ext.browser.js
@@ -19,8 +19,9 @@ function extBrowserSetup(app, spaFlags, document, ele) {
         return (node && isChild(node.parentNode));
     }
     ele.addEventListener("click", function(event) {
-        if (! isChild(event.target)) return;
+        if (event.metaKey || event.ctrlKey) return;
         if (! (event.target && event.target.href)) return;
+        if (! isChild(event.target)) return;
         event.preventDefault();
         app.ports.onLocationRequest.send([locationObject(window.location), locationObject(event.target)]);
     }, false);

--- a/index.html
+++ b/index.html
@@ -4,14 +4,22 @@
   <meta charset="UTF-8">
   <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
   <title>Main</title>
+  <script src="/ext.browser.js"></script>
   <script src="/output.js"></script>
 </head>
 <body>
-    <div id="elm"></div>
+    <div id="elmIsolation">
+        <div id="elm"></div>
+    </div>
     <script>
+      var spaFlags = generateSpaFlags()
       var app = Elm.Main.init({
+          flags:
+              { spaFlags: spaFlags
+              },
           node: document.getElementById("elm")
       });
+      extBrowserSetup(app, spaFlags, document, document.getElementById("elmIsolation"));
     </script>
 </body>
 </html>

--- a/src/Ext/Browser.elm
+++ b/src/Ext/Browser.elm
@@ -1,0 +1,65 @@
+port module Ext.Browser exposing
+    ( Location
+    , UrlRequest(..)
+    , setPageTitle
+    , urlFromLocation
+    )
+
+import Html
+import Url
+
+
+type UrlRequest
+    = Internal Url.Url
+    | External String
+
+
+{-| maps to properties that we get from window.location or a <a href/> element
+...except for `port` vs `port_`
+-}
+type alias Location =
+    { protocol : String
+    , host : String
+    , port_ : String
+    , pathname : String
+    , search : String
+    , hash : String
+    }
+
+
+{-| the nice thing about `Location` is that it can pass through ports
+and be converted into Url.Url plainly
+-}
+urlFromLocation : Location -> Url.Url
+urlFromLocation location =
+    let
+        nothingIfBlank s =
+            case String.trim s of
+                "" ->
+                    Nothing
+
+                notBlank ->
+                    Just notBlank
+
+        chompLeft substr string =
+            if String.startsWith substr string then
+                String.dropLeft (String.length substr) string
+
+            else
+                string
+    in
+    { protocol =
+        if location.protocol == "https:" then
+            Url.Https
+
+        else
+            Url.Http
+    , host = location.host
+    , port_ = Maybe.andThen String.toInt (nothingIfBlank location.port_)
+    , path = location.pathname
+    , query = Maybe.map (chompLeft "?") (nothingIfBlank location.search)
+    , fragment = Maybe.map (chompLeft "#") (nothingIfBlank location.hash)
+    }
+
+
+port setPageTitle : String -> Cmd msg

--- a/src/Ext/Browser.elm
+++ b/src/Ext/Browser.elm
@@ -2,6 +2,7 @@ port module Ext.Browser exposing
     ( Location
     , UrlRequest(..)
     , setPageTitle
+    , style
     , urlFromLocation
     )
 
@@ -63,3 +64,8 @@ urlFromLocation location =
 
 
 port setPageTitle : String -> Cmd msg
+
+
+style : List (Html.Attribute msg) -> List (Html.Html msg) -> Html.Html msg
+style attr child =
+    Html.div [] [ Html.node "style" attr child ]

--- a/src/Ext/Browser/Navigation.elm
+++ b/src/Ext/Browser/Navigation.elm
@@ -1,0 +1,95 @@
+module Ext.Browser.Navigation exposing
+    ( Key
+    , SpaFlags
+    , back
+    , forward
+    , load
+    , onUrlChange
+    , onUrlRequest
+    , pushUrl
+    , reload
+    , reloadAndSkipCache
+    , replaceUrl
+    , spaFlags
+    )
+
+import Browser.Navigation
+import Ext.Browser
+import Ext.Browser.Ports
+import Url
+
+
+type Key
+    = Key Float
+
+
+type alias SpaFlags =
+    { location : Ext.Browser.Location
+    , navKey : Float
+    }
+
+
+spaFlags : { a | spaFlags : SpaFlags } -> { url : Url.Url, navKey : Key }
+spaFlags record =
+    { url = Ext.Browser.urlFromLocation record.spaFlags.location
+    , navKey = Key record.spaFlags.navKey
+    }
+
+
+pushUrl : Key -> String -> Cmd msg
+pushUrl (Key k) arg =
+    Ext.Browser.Ports.pushUrl ( k, arg )
+
+
+replaceUrl : Key -> String -> Cmd msg
+replaceUrl (Key k) arg =
+    Ext.Browser.Ports.replaceUrl ( k, arg )
+
+
+back : Key -> Int -> Cmd msg
+back (Key k) arg =
+    Ext.Browser.Ports.back ( k, arg )
+
+
+forward : Key -> Int -> Cmd msg
+forward (Key k) arg =
+    Ext.Browser.Ports.forward ( k, arg )
+
+
+onUrlChange : (Url.Url -> msg) -> Sub msg
+onUrlChange msg =
+    Ext.Browser.Ports.onLocationChange (Ext.Browser.urlFromLocation >> msg)
+
+
+onUrlRequest : (Ext.Browser.UrlRequest -> msg) -> Sub msg
+onUrlRequest msg =
+    Ext.Browser.Ports.onLocationRequest
+        (\( before, after ) ->
+            if
+                before.protocol
+                    == after.protocol
+                    && before.host
+                    == after.host
+                    && before.port_
+                    == after.port_
+            then
+                msg (Ext.Browser.Internal (Ext.Browser.urlFromLocation after))
+
+            else
+                msg (Ext.Browser.External (Url.toString (Ext.Browser.urlFromLocation after)))
+        )
+
+
+load : String -> Cmd msg
+load =
+    Browser.Navigation.load
+
+
+reload : Cmd msg
+reload =
+    Browser.Navigation.reload
+
+
+reloadAndSkipCache : Cmd msg
+reloadAndSkipCache =
+    Browser.Navigation.reloadAndSkipCache

--- a/src/Ext/Browser/Ports.elm
+++ b/src/Ext/Browser/Ports.elm
@@ -1,0 +1,21 @@
+port module Ext.Browser.Ports exposing (..)
+
+import Ext.Browser exposing (Location)
+
+
+port pushUrl : ( Float, String ) -> Cmd msg
+
+
+port replaceUrl : ( Float, String ) -> Cmd msg
+
+
+port back : ( Float, Int ) -> Cmd msg
+
+
+port forward : ( Float, Int ) -> Cmd msg
+
+
+port onLocationChange : (Location -> msg) -> Sub msg
+
+
+port onLocationRequest : (( Location, Location ) -> msg) -> Sub msg

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -118,7 +118,7 @@ view model =
                 , text " | "
                 , a [ href "/three" ] [ text "three" ]
                 ]
-            , Html.node "style" [] [ text "a { font-style: italic; }" ]
+            , Ext.Browser.style [] [ text "a { font-style: italic; }" ]
             , text ("Current url: " ++ Url.toString model.url)
             , div [ class "grid grid-flow-row grid-cols-1 md:grid-cols-2 gap-4" ]
                 (Array.indexedMap userInputArea model.paragraphs


### PR DESCRIPTION
_UPDATE: added a preview link to test *your* chrome extensions https://elm-element-navigation.netlify.app/_

## Before

Elm app does NOT work in browser with these extensions installed

https://user-images.githubusercontent.com/473/120914526-587d4000-c6d1-11eb-8c1a-47e6510ecbb2.mov

(the initial sluggishness when demoing the new branch is due to `ChromeVox` not elm or the patch itself)

## After

Elm app now works in browser with these extensions installed

- BlazeMeter
- Dark Reader
- Evernote Web Clipper
- Google Translate
- Grammarly
- Screen Reader aka ChromeVox
- StayFocusd

<img width="1392" alt="Screenshot 2021-06-06 at 2 12 36 PM" src="https://user-images.githubusercontent.com/473/120914584-ab56f780-c6d1-11eb-974a-235a6f102427.png">

